### PR TITLE
Upgrade musl to 1.2.3

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -209,22 +209,6 @@ jobs:
           TARGET: i686-unknown-linux-musl
           RUST_MUSL_MAKE_CONFIG: config.mak
           TOOLCHAIN: stable
-        - IMAGE_TAG: mips-musl
-          TARGET: mips-unknown-linux-musl
-          RUST_MUSL_MAKE_CONFIG: config.mak
-          TOOLCHAIN: stable
-        - IMAGE_TAG: mips64-muslabi64
-          TARGET: mips64-unknown-linux-muslabi64
-          RUST_MUSL_MAKE_CONFIG: config.mak
-          TOOLCHAIN: stable
-        - IMAGE_TAG: mips64el-muslabi64
-          TARGET: mips64el-unknown-linux-muslabi64
-          RUST_MUSL_MAKE_CONFIG: config.mak
-          TOOLCHAIN: stable
-        - IMAGE_TAG: mipsel-musl
-          TARGET: mipsel-unknown-linux-musl
-          RUST_MUSL_MAKE_CONFIG: config.mak
-          TOOLCHAIN: stable
         - IMAGE_TAG: powerpc64le-musl
           TARGET: powerpc64le-unknown-linux-musl
           RUST_MUSL_MAKE_CONFIG: config.mak

--- a/config.mak
+++ b/config.mak
@@ -18,10 +18,7 @@ OUTPUT = /usr/local/musl
 # BINUTILS_VER =
 GCC_VER = 11.2.0
 
-# https://github.com/rust-embedded/cross/issues/478
-# https://github.com/rust-lang/libc/issues/1848
-
-MUSL_VER = 1.1.24
+MUSL_VER = 1.2.3
 
 # GMP_VER =
 # MPC_VER =

--- a/config.mak.aarch64
+++ b/config.mak.aarch64
@@ -21,10 +21,7 @@ OUTPUT = /usr/local/musl
 # https://github.com/messense/rust-musl-cross/pull/67#issuecomment-1251905512
 GCC_VER = 9.2.0
 
-# https://github.com/rust-embedded/cross/issues/478
-# https://github.com/rust-lang/libc/issues/1848
-
-MUSL_VER = 1.1.24
+MUSL_VER = 1.2.3
 
 # GMP_VER =
 # MPC_VER =


### PR DESCRIPTION
Now that Rust 1.71.0 uses musl 1.2.

Closes #113 