### PR TITLE
Dockerfile: add static linking for riscv64gc musl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # here is to support the musl-libc builds and Cargo builds needed for a
 # large selection of the most popular crates.
 #
-RUN apt-get update && \
-    apt-get install -y \
+RUN for i in 1 2 3 4 5; do \
+        apt-get update && break || sleep 5; \
+    done && \
+    for i in 1 2 3 4 5; do \
+        apt-get install -y \
     build-essential \
     cmake \
     curl \
@@ -27,7 +30,8 @@ RUN apt-get update && \
     llvm-dev \
     libclang-dev \
     clang \
-    && \
+    && break || { apt-get update; sleep 5; }; \
+    done && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Let's Encrypt R3 CA certificate from https://letsencrypt.org/certificates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,5 +132,8 @@ ENV CARGO_TARGET_MIPS64_OPENWRT_LINUX_MUSL_RUSTFLAGS='-C target-feature=+crt-sta
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUSTFLAGS='-C target-feature=+crt-static'
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUSTFLAGS='-C target-feature=+crt-static'
 
+# Build statically linked binaries for RISCV64GC targets
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS='-C target-feature=+crt-static'
+
 # Expect our source code to live in /home/rust/src
 WORKDIR /home/rust/src

--- a/config.mak
+++ b/config.mak
@@ -29,7 +29,12 @@ MUSL_VER = 1.2.5
 # By default source archives are downloaded with wget. curl is also an option.
 
 # DL_CMD = wget -c -O
-DL_CMD = curl -C - -L -o
+DL_CMD = curl -C - -L -f --retry 5 --retry-delay 2 -o
+
+# ftpmirror.gnu.org sometimes round-robins to a stale mirror missing an
+# older release, returning a 502 that curl -f now catches instead of
+# silently writing to the source archive. Pin the canonical GNU host.
+GNU_SITE = https://ftp.gnu.org/gnu
 
 # Something like the following can be used to produce a static-linked
 # toolchain that's deployable to any system with matching arch, using


### PR DESCRIPTION
Follow a similar pattern as MIPS* to do static linking for crt-static in the riscv64gc musllinux case. Otherwise, we can encounter build errors for packages like:

|  🎯 Found 2 Cargo targets in Cargo.toml: foo, hello-world
|      Finished dev profile [unoptimized + debuginfo] target(s) in 0.01s
|      Finished dev profile [unoptimized + debuginfo] target(s) in 0.01s
|  🔗 External shared libraries to be copied into the wheel:
|    /home/runner/work/maturin-action/maturin-action/maturin/test-crates/hello-world/target/maturin/foo requires:
|      libgcc_s-998f13c4.so.1 => not found
|    /home/runner/work/maturin-action/maturin-action/maturin/test-crates/hello-world/target/maturin/hello-world requires:
|      libgcc_s-998f13c4.so.1 => not found
|  💥 maturin failed
|    Caused by: Cannot repair wheel, because required library libgcc_s-998f13c4.so.1 could not be located.
|  Error: The process '/usr/bin/docker' failed with exit code 1